### PR TITLE
Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val Scala2_11  = "2.11.12"
 val Scala2_12  = "2.12.15"
 val Scala2_13  = "2.13.8"
 val Scala3     = "3.1.1"
-val ScalaTest  = "3.2.11"
+val ScalaTest  = "3.2.12"
 
 val SharedSettings = Seq(
   name         := "trail",
@@ -56,20 +56,6 @@ lazy val trail = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.scalatest" %%% s"scalatest-$module" % ScalaTest % Test
     )
   )
-
-lazy val trailNative = trail.native.settings(
-  // ScalaTest is not yet published for Scala 3 Native
-  libraryDependencies := {
-    val deps = libraryDependencies.value
-
-    if(isScala3(scalaVersion.value))
-      deps.filterNot(_.organization == "org.scalatest")
-    else deps
-  },
-  Test / test := {
-    if(isScala3(scalaVersion.value)) {} else (Test / test).value
-  }
-)
 
 lazy val manual = project.in(file("manual"))
   .dependsOn(trail.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,15 @@ val SharedSettings = Seq(
 
   scalaVersion       := Scala2_13,
   crossScalaVersions := Seq(Scala3, Scala2_13, Scala2_12, Scala2_11),
-  scalacOptions      := Seq(
-    "-unchecked",
-    "-deprecation",
-    "-encoding", "utf8"
-  ),
+  scalacOptions      := {
+    // Preserve -scalajs flag used by Scala.js on Scala 3
+    scalacOptions.value.filter(_ == "-scalajs") ++ 
+    Seq(
+      "-unchecked",
+      "-deprecation",
+      "-encoding", "utf8"
+    )
+  },
 
   pomExtra :=
     <url>https://github.com/sparsetech/trail</url>

--- a/native/src/main/scala/trail/URI.scala
+++ b/native/src/main/scala/trail/URI.scala
@@ -25,7 +25,7 @@ object URI {
       if (c == '+') result.append(' ')
       else if (c == '%') {
         out.reset()
-        do {
+        while({
           if (i + 2 >= s.length)
             throw new IllegalArgumentException("Incomplete % sequence at: " + i)
           val d1 = Character.digit(s.charAt(i + 1), 16)
@@ -35,7 +35,8 @@ object URI {
               s"Invalid % sequence (${s.substring(i, i + 3)}) at: ${String.valueOf(i)}.")
           out.write(((d1 << 4) + d2).toByte)
           i += 3
-        } while (i < s.length && s.charAt(i) == '%')
+          (i < s.length && s.charAt(i) == '%')
+        }) { }
         result.append(out.toString("UTF-8"))
       } else {
         result.append(c)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ logLevel := Level.Warn
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.3.1")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.9.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.4")

--- a/shared/src/main/scala/trail/PathElement.scala
+++ b/shared/src/main/scala/trail/PathElement.scala
@@ -1,6 +1,6 @@
 package trail
 
-case class Arg[T]()(implicit val codec: Codec[T]) {
+class Arg[T]()(implicit val codec: Codec[T]) {
   override def equals(o: Any): Boolean =
     o match {
       case a: Arg[T] => a.codec.equals(codec)
@@ -8,6 +8,10 @@ case class Arg[T]()(implicit val codec: Codec[T]) {
     }
 
   override def hashCode(): Int = ("trail.Arg", codec).hashCode()
+}
+
+object Arg {
+  def apply[T](implicit codec: Codec[T]) = new Arg()
 }
 
 case class Param[T](name: String)(implicit val codec: Codec[T]) {
@@ -20,7 +24,7 @@ case class Param[T](name: String)(implicit val codec: Codec[T]) {
   override def hashCode(): Int = ("trail.Param", name, codec).hashCode()
 }
 
-case class Fragment[T]()(implicit val codec: Codec[T]) {
+class Fragment[T](implicit val codec: Codec[T]) {
   override def equals(o: Any): Boolean =
     o match {
       case f: Fragment[T] => f.codec.equals(codec)
@@ -28,4 +32,8 @@ case class Fragment[T]()(implicit val codec: Codec[T]) {
     }
 
   override def hashCode(): Int = ("trail.Fragment", codec).hashCode()
+}
+
+object Fragment {
+  def apply[T](implicit codec: Codec[T]) = new Fragment[T]
 }


### PR DESCRIPTION
There are some non-trivial changes that I had to make, so let's have a discussion here.

1. Add Scala 3 to cross build
2. Exclude Scala 3 Native combination from tests (see https://github.com/scalatest/scalatest/issues/2097)
3. Adjust flags for the Scala.js on Scala 3 combination
4. Update SBT to 1.6.x
5. Update Scala.js to 1.9.0 (can be dropped down to 1.7.0, but not lower as that's the IR version that Dotty starts out with)
6. Change `do...while` to recommended construct in https://docs.scala-lang.org/scala3/reference/dropped-features/do-while.html
7. **Remove auto-application issue on Scala 3 (see https://docs.scala-lang.org/scala3/reference/dropped-features/auto-apply.html#inner-main)** - this is not binary compatible, as I removed `case` from Arg and Fragment classes